### PR TITLE
mark nodes unhealthy if over 100 blocks away from highest

### DIFF
--- a/xmrnodes/helpers.py
+++ b/xmrnodes/helpers.py
@@ -9,6 +9,7 @@ from levin.bucket import Bucket
 from levin.ctypes import *
 from levin.constants import LEVIN_SIGNATURE
 
+from xmrnodes.models import Node
 from xmrnodes import config
 
 
@@ -119,3 +120,11 @@ def retrieve_peers(host, port):
         return peers
     else:
         return None
+
+def get_highest_block(nettype, crypto):
+    highest = Node.select().where(
+        Node.validated == True,
+        Node.nettype == nettype,
+        Node.crypto == crypto
+    ).order_by(Node.last_height.desc()).limit(1).first()
+    return highest.last_height

--- a/xmrnodes/templates/index.html
+++ b/xmrnodes/templates/index.html
@@ -42,7 +42,9 @@
     {% if nodes %}
     <div class="xmrnodes">
       <p class="center">
-        Tracking {{ nodes_all }} {{ nettype }} {{ crypto | capitalize }} nodes in the database. Of those, {{ nodes_unhealthy }} nodes failed their last check-in.
+        Tracking {{ nodes_all }} {{ nettype }} {{ crypto | capitalize }} nodes in the database.
+        <br>
+        Of those, {{ nodes_unhealthy }} nodes failed their last check-in (unresponsive to ping or over 100 blocks away from highest reported block).
       </p>
       <p class="center">Showing {{ nodes | length }} nodes.
         {% if 'all' not in request.args %}


### PR DESCRIPTION
It was pointed out to me that many of the nodes being displayed were very out of date. They were responding to my pings, but advertising a block height that was very old, most likely due to not being updated to latest Monero release.

This PR updates the check logic to mark as healthy/unhealthy if within a 100 block threshold of the highest known block, also the app logic to only show nodes within the threshold (unless all nodes requested).