### PR TITLE
Update resources.html

### DIFF
--- a/xmrnodes/templates/resources.html
+++ b/xmrnodes/templates/resources.html
@@ -37,7 +37,7 @@
 
       <h3>How Do I Run My Own Node?</h3>
       <p>
-        There are plenty of guides out there that explain in great detail how you can run a Monero node, so I will defer to those. This is my favorite resource to learn about setting up your own node: <a href="https://sethsimmons.me/guides/run-a-monero-node/" target="_blank">Run a Monero Node by Seth Simmons</a>.
+        There are plenty of guides out there that explain in great detail how you can run a Monero node, so I will defer to those. This is my favorite resource to learn about setting up your own node: <a href="https://sethforprivacy.com/guides/run-a-monero-node" target="_blank">Run a Monero Node by Seth Simmons</a>.
         If you're not technical but still want to support the network, please check out my node launching site, <a href="https://xmrcannon.net" target="_blank">XMR Node Cannon</a>.
       </p>
 


### PR DESCRIPTION
Change link for the guide to setting up your own node,

https://web.archive.org/web/20211019020556/https://sethsimmons.me/guides/run-a-monero-node/ redirected to the new url that is https://sethforprivacy.com/guides/run-a-monero-node before the domain name "expired?" and now redirects to a malware url.